### PR TITLE
Remove non-abilities in abilities list Player.tsx

### DIFF
--- a/scripts/update-static-data.cjs
+++ b/scripts/update-static-data.cjs
@@ -431,6 +431,13 @@ export function getAbilityByShortName(shortName: string): Ability | undefined {
   return abilitiesByShortName[shortName]
 }
 
+/** Check if a valveId is truly an ability */
+export function isAbilityId(id: number): boolean {
+  return (id > 0
+    && id != 5368 // Ignore Greevil's Greed
+  );
+}
+
 /** Total number of abilities */
 export const ABILITY_COUNT = ${abilityCount}
 `;

--- a/src/data/abilities.ts
+++ b/src/data/abilities.ts
@@ -61520,5 +61520,12 @@ export function getAbilityByShortName(shortName: string): Ability | undefined {
   return abilitiesByShortName[shortName]
 }
 
+/** Check if a valveId is truly an ability */
+export function isAbilityId(id: number): boolean {
+  return (id > 0
+    && id != 5368 // Ignore Greevil's Greed
+  );
+}
+
 /** Total number of abilities */
 export const ABILITY_COUNT = 3075

--- a/src/pages/Player.tsx
+++ b/src/pages/Player.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo } from 'react'
 import { useParams, Link, useNavigate } from 'react-router-dom'
 import { usePlayerData, usePlayerMatches, usePlayerStats, useAuth } from '../api'
-import { getAbilityById, getHeroById } from '../data'
+import { getAbilityById, getHeroById, isAbilityId } from '../data'
 import { heroMiniUrl, heroImageUrl } from '../config'
 import type { PlayerMatch, PlayerMatchPlayer, SpellStat, WinLossStats } from '../types/player'
 import styles from './Player.module.css'
@@ -402,6 +402,7 @@ export function PlayerPage() {
                 }))
                 .sort((a, b) => abilitySort === 'games' ? b.total - a.total : b.winrate - a.winrate)
                 .map(({ abilityId, wins, losses, winrate, total, avgPickPosition }) => {
+                  if (!isAbilityId(abilityId)) return null
                   const ability = getAbilityById(abilityId)
                   return ability ? (
                     <div key={abilityId} className={styles.statsListRow}>


### PR DESCRIPTION
Removes heroes / innates appearing in the Abilities box on the players page.

example: https://windrun.io/players/74675113

Before:
<img width="439" height="413" alt="image" src="https://github.com/user-attachments/assets/45bd01b1-3007-47f0-83b5-fd9f279dba75" />


After:
<img width="440" height="409" alt="image" src="https://github.com/user-attachments/assets/bcb88625-884f-4941-b42f-f01981b35aa6" />
