### PR TITLE
Add scroll forwarding for all pages

### DIFF
--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -200,6 +200,7 @@ export function DataTable<T>({
         ref={tableContainerRef}
         className={styles.tableContainer}
         style={{ maxHeight }}
+        data-scroll-target
       >
         <table className={styles.table}>
           <thead className={styles.thead}>

--- a/src/components/PageShell.tsx
+++ b/src/components/PageShell.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react'
+import { useScrollForwarding } from '../hooks/ScrollForwarding'
 import styles from './PageShell.module.css'
 
 interface PageShellProps {
@@ -7,6 +8,7 @@ interface PageShellProps {
   actions?: ReactNode
   children: ReactNode
   compact?: boolean
+  contentIsScrollTarget?: boolean
 }
 
 export function PageShell({
@@ -15,7 +17,9 @@ export function PageShell({
   actions,
   children,
   compact = false,
+  contentIsScrollTarget = false,
 }: PageShellProps) {
+  useScrollForwarding()
   return (
     <div className={`${styles.shell} ${compact ? styles.shellCompact : ''}`}>
       {(title || subtitle || actions) && (
@@ -34,7 +38,7 @@ export function PageShell({
         </header>
       )}
 
-      <div className={styles.content}>{children}</div>
+      <div className={styles.content} data-scroll-target={contentIsScrollTarget}>{children}</div>
     </div>
   )
 }

--- a/src/hooks/ScrollForwarding.tsx
+++ b/src/hooks/ScrollForwarding.tsx
@@ -1,0 +1,30 @@
+import { useEffect } from 'react'
+
+// Forwards scroll events to any element with `data-scroll-target=true`.
+export function useScrollForwarding() {
+  useEffect(() => {
+    const onScroll = (e: WheelEvent) => {
+      const scrollableElement = document.querySelector('[data-scroll-target=true]') as HTMLElement
+
+      // If theres no scrollable element or the event originated from within it, do nothing
+      if (!scrollableElement
+          || scrollableElement.contains(e.target as Node)) {
+        return
+      }
+      
+      // Check if there's room to scroll
+      const { scrollTop, scrollHeight, clientHeight } = scrollableElement
+      const canScrollUp = scrollTop > 0
+      const canScrollDown = scrollTop < scrollHeight - clientHeight
+
+      // Only prevent default and forward if there's room to scroll in that direction
+      if ((e.deltaY < 0 && canScrollUp) || (e.deltaY > 0 && canScrollDown)) {
+        e.preventDefault()
+        scrollableElement.scrollTop += e.deltaY
+      }
+    }
+
+    document.addEventListener('wheel', onScroll, { passive: false })
+    return () => document.removeEventListener('wheel', onScroll)
+  }, [])
+}

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -3,7 +3,7 @@ import styles from './About.module.css'
 
 export function AboutPage() {
   return (
-    <PageShell title="About">
+    <PageShell title="About" contentIsScrollTarget={true}>
       <div className={styles.content}>
         <section className={styles.section}>
           <h2 className={styles.sectionTitle}>About Windrun</h2>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -342,7 +342,7 @@ export function HomePage() {
   }, [chartData])
 
   return (
-    <PageShell>
+    <PageShell contentIsScrollTarget={true}>
       <div className={styles.hero}>
         <h1 className={styles.title}>WINDRUN</h1>
         <p className={styles.tagline}>Ability Draft Statistics</p>

--- a/src/pages/Player.tsx
+++ b/src/pages/Player.tsx
@@ -5,6 +5,7 @@ import { getAbilityById, getHeroById, isAbilityId } from '../data'
 import { heroMiniUrl, heroImageUrl } from '../config'
 import type { PlayerMatch, PlayerMatchPlayer, SpellStat, WinLossStats } from '../types/player'
 import styles from './Player.module.css'
+import { useScrollForwarding } from '../hooks/ScrollForwarding'
 
 function formatRatingWhole(rating: number): string {
   return Math.round(rating).toString()
@@ -87,6 +88,7 @@ export function PlayerPage() {
       }
     }
   }, [isMe, authLoading, user, navigate, login])
+  useScrollForwarding()
 
   const { data: playerResponse, isLoading: playerLoading, error: playerError } = usePlayerData(playerId ?? '')
   const { data: matchesResponse, isLoading: matchesLoading } = usePlayerMatches(playerId ?? '', page)
@@ -151,7 +153,7 @@ export function PlayerPage() {
   const steam64Id = BigInt(player.steamId) + BigInt('76561197960265728')
 
   return (
-    <div className={styles.page}>
+    <div className={styles.page} data-scroll-target>
       {/* Profile Header */}
       <div className={styles.header}>
         <img src={player.avatar} alt="" className={styles.avatar} />


### PR DESCRIPTION
On all pages, scrolling on the left/right margins does not work. This may be surprising / inconvenient to some users.

Added a scroll listener that forwards any scroll events to any div with the property `data-scroll-target`

Tested edge cases like the patch selector scroll wheel, and the player page which has nested scrollable content.

Demo: https://youtu.be/AuvULKnGDq4

Out of scope: middle mouse click scroll