### PR TITLE
Fix #20 (% on High Skill avg-pick) + add a build CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build

--- a/src/pages/AbilityHighSkill.tsx
+++ b/src/pages/AbilityHighSkill.tsx
@@ -217,6 +217,7 @@ export function AbilityHighSkillPage() {
             max={40}
             decimals={1}
             invert={true}
+            suffix=""
           />
         ),
       },
@@ -243,6 +244,7 @@ export function AbilityHighSkillPage() {
             max={40}
             decimals={1}
             invert={true}
+            suffix=""
           />
         ),
       },


### PR DESCRIPTION
Hey @Noxville — long-time reader of windrun.io, thought I'd send a small contribution. The site is a great resource for AD players. Two unrelated but small changes bundled here so you only have to review once; happy to split if you'd prefer.

## 1. Fix #20: `%` on High Skill avg-pick columns

The `GradientCell` component defaults `suffix='%'`, which is correct for the win-rate columns but renders avg-pick (a 1–40 position number) as e.g. `12.3%`. This is exactly what the screenshot in #20 shows.

`Abilities.tsx` already handles this correctly by passing `suffix=""` explicitly on its pick-position columns. I followed the same pattern in `AbilityHighSkill.tsx` for `avgPickHighSkill` and `avgPickAll`.

I considered changing the `GradientCell` default to `''` instead, but that has more blast radius — every page using `GradientCell` for win-rates would need an explicit `suffix="%"`. Left the default alone, only fixed the two call sites that were rendering wrong.

**Files changed:** `src/pages/AbilityHighSkill.tsx` (+2 lines)

## 2. Add a build workflow

There are no GitHub Actions workflows in the repo yet, so PRs (including this one) can't get a green check. I added `.github/workflows/build.yml` that runs `npm ci && npm run build` on push to `main` and on every PR.

This catches TypeScript or Vite build regressions before deploy, which seemed worth it given the manual `scp` deploy mentioned in the README.

**A couple of conscious choices:**

- **`npm run lint` left out on purpose.** Running it on `main` right now produces 32 errors (mostly `@typescript-eslint/no-explicit-any` and `react-hooks/static-components`), so turning it on as a CI gate without first cleaning them up would block every future PR. Happy to do a separate lint-cleanup PR if you'd like, or you can wire lint in later when convenient.
- **Node 20** (current LTS) — change to whatever matches your local dev if different.

**Files changed:** `.github/workflows/build.yml` (new file, 24 lines)

---

## Verifying

- Ran `npm ci && npm run build` locally — clean build, no new warnings.
- Manually verified the avg-pick columns render as plain numbers in dev (no `%`).

Happy to revise either of these — or split into two PRs if you'd prefer to merge them independently. Thanks for windrun.io!
