### PR TITLE
Mobile nav: fix login button overlapping page H1, bump hamburger to 44px

### DIFF
--- a/src/components/Navigation.module.css
+++ b/src/components/Navigation.module.css
@@ -366,9 +366,9 @@
    ============================================ */
 .mobileToggle {
   display: none;
-  width: 32px;
-  height: 32px;
-  padding: 6px;
+  width: 44px;
+  height: 44px;
+  padding: 12px;
   background: none;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
@@ -420,6 +420,10 @@
    RESPONSIVE
    ============================================ */
 @media (max-width: 900px) {
+  .nav {
+    position: relative;
+  }
+
   .mobileToggle {
     display: flex;
     align-items: center;
@@ -483,35 +487,15 @@
   }
 
   .auth {
-    position: absolute;
-    top: 100%;
-    right: var(--space-md);
-    margin-top: var(--space-md);
-  }
-
-  .linksOpen + .auth {
-    position: static;
-    margin-top: var(--space-md);
-    padding-top: var(--space-md);
-    border-top: 1px solid var(--color-border);
-    width: 100%;
-    justify-content: center;
-  }
-}
-
-@media (max-width: 900px) {
-  .nav {
-    position: relative;
-  }
-
-  .auth {
-    order: 3;
+    display: none;
   }
 
   .linksOpen ~ .auth {
-    position: static;
+    display: flex;
+    width: 100%;
     margin: 0;
     padding-top: var(--space-md);
     border-top: 1px solid var(--color-border);
+    justify-content: center;
   }
 }


### PR DESCRIPTION
Hey @Noxville — second small contribution. Two related fixes for the mobile nav, both behind `@media (max-width: 900px)` so desktop is untouched. Let me know if you'd rather have these split.

This **does not** touch tables / DataTable / wide pages — that's a much bigger conversation about column collapsing or card mode under ~640px and I want to talk about scope before I start. Happy to hear your thoughts in a separate issue or here.

## 1. "Log in with Steam" no longer overlaps the page H1

**Before:** in `Navigation.module.css`, the `.auth` block (login button or user menu) had `position: absolute; top: 100%; right: var(--space-md); margin-top: var(--space-md);` inside the `≤900px` media query. So even when the hamburger menu was *closed*, the auth block was rendered as a floating element below the nav header — landing on top of the page H1 (visible on Leaderboard, Player profile, Hero detail, Ability detail, etc.).

**After:** hidden when the mobile menu is closed, shown inline at the bottom of the drawer when it opens (using the existing `.linksOpen ~ .auth` sibling selector). Login stays reachable, same model as the rest of the nav items.

I also collapsed the two duplicate `@media (max-width: 900px)` blocks at the bottom of the file into one — there were a few overlapping rules across them, slightly unwound the redundancy while I was in there.

## 2. Hamburger toggle bumped from 32×32 → 44×44

WCAG / Lighthouse `target-size` flags anything under 44×44 as a tap target violation, and the hamburger was 32×32. The icon (the bars) stays the same visual size — just gave the button enough padding to clear 44×44.

## Verification

- `npm run build` clean, no new warnings.
- Sanity-checked the selector logic by reading the CSS — `.auth` defaults to `display: flex` from the base rule, mobile media query sets it to `display: none`, then `.linksOpen ~ .auth` flips it back to `display: flex` when the drawer opens. Should be no flash on toggle.
- Tested mentally across the auth states: logged out (Steam button), logged in (user menu + sign out) — both go through `.auth` so both are gated by the new visibility logic.

## What's next

If this lands, I want to do a follow-up PR for the heroes / abilities / leaderboard tables on mobile — they currently render their full desktop column set inside an `overflow-x: auto` wrapper, which produces the "horizontal scroll inside a sub-frame" UX that issue #8 calls out. Open to suggestions on the right approach (priority-column hiding via TanStack `columnVisibility`, vs. card mode under 640px, vs. sticky first column + visible scroll affordance) — happy to start a separate issue or sketch a small POC PR if you'd prefer.
